### PR TITLE
Specify thread group dimensions for compute shaders

### DIFF
--- a/Libraries/Aurora/Source/DirectX/PTRenderer.cpp
+++ b/Libraries/Aurora/Source/DirectX/PTRenderer.cpp
@@ -1427,14 +1427,19 @@ void PTRenderer::submitAccumulation(uint32_t sampleIndex)
     pCommandList->SetPipelineState(_pAccumulationPipelineState.Get());
 
     // Set the root signature arguments for accumulation: the descriptor table and the accumulation
-    // settings. The descriptor table must start with the accumulation texture. Then dispatch the
-    // accumulation shader, which performs (optional) deferred shading and merges new path tracing
-    // samples with the previous results.
+    // settings. The descriptor table must start with the accumulation texture.
     CD3DX12_GPU_DESCRIPTOR_HANDLE handle(_pDescriptorHeap->GetGPUDescriptorHandleForHeapStart(),
         kAccumulationDescriptorOffset, _handleIncrementSize);
     pCommandList->SetComputeRootDescriptorTable(0, handle);
     pCommandList->SetComputeRoot32BitConstants(1, sizeof(Accumulation) / 4, &_accumData, 0);
-    pCommandList->Dispatch(_outputDimensions.x, _outputDimensions.y, 1);
+
+    // Dispatch the accumulation shader, which performs (optional) deferred shading and merges new
+    // path tracing samples with the previous results.
+    // NOTE: The dispatch is performed with thread group dimensions that provide good occupancy for
+    // the current compute shader code. This must match the values in the compute shader.
+    constexpr uvec2 kThreadGroupCount(16, 8);
+    pCommandList->Dispatch((_outputDimensions.x + kThreadGroupCount.x - 1) / kThreadGroupCount.x,
+        (_outputDimensions.y + kThreadGroupCount.y - 1) / kThreadGroupCount.y, 1);
 
     // Submit the command list.
     submitCommandList();
@@ -1460,17 +1465,23 @@ void PTRenderer::submitPostProcessing()
 
     // Set the root signature arguments for post-processing: the descriptor table (at the start of
     // the heap) and the post-processing settings. The descriptor table must start with the final
-    // texture. Then dispatch the post-processing shader, which tone maps (as needed) the
-    // accumulation texture (HDR) to the final texture (usually SDR).
-    // NOTE: Even if the settings mean no post-processing is performed, there is still an implicit
-    // format conversion, from the accumulation texture (UAV) format to the output texture format,
-    // e.g. floating-point to integer.
+    // texture.
     CD3DX12_GPU_DESCRIPTOR_HANDLE handle(_pDescriptorHeap->GetGPUDescriptorHandleForHeapStart(),
         kFinalDescriptorOffset, _handleIncrementSize);
     pCommandList->SetComputeRootDescriptorTable(0, handle);
     pCommandList->SetComputeRoot32BitConstants(
         1, sizeof(PostProcessing) / 4, &_postProcessingData, 0);
-    pCommandList->Dispatch(_outputDimensions.x, _outputDimensions.y, 1);
+
+    // Dispatch the post-processing shader, which tone maps(as needed) the accumulation texture
+    // (HDR) to the final texture (usually SDR).
+    // NOTE: This should be done even if the settings mean no post-processing is performed as there
+    // is still an implicit format conversion, from the accumulation texture (UAV) format to the
+    // output texture format, e.g. floating-point to integer.
+    // NOTE: The dispatch is performed with thread group dimensions that provide good occupancy for
+    // the current compute shader code. This must match the values in the compute shader.
+    constexpr uvec2 kThreadGroupCount(16, 8);
+    pCommandList->Dispatch((_outputDimensions.x + kThreadGroupCount.x - 1) / kThreadGroupCount.x,
+        (_outputDimensions.y + kThreadGroupCount.y - 1) / kThreadGroupCount.y, 1);
 
     // Copy the output textures to their associated targets, if any.
     copyTextureToTarget(_pTexFinal.Get(), _pTargetFinal.get());

--- a/Libraries/Aurora/Source/DirectX/Shaders/Accumulation.hlsl
+++ b/Libraries/Aurora/Source/DirectX/Shaders/Accumulation.hlsl
@@ -43,11 +43,21 @@ struct Accumulation
 ConstantBuffer<Accumulation> gSettings : register(b0);
 
 // A compute shader that accumulates path tracing results, optionally with denoising.
+// NOTE: The indicated thread group dimensions provide good occupancy for the current code, and
+// must match the values at the Dispatch() call.
 [RootSignature(ROOT_SIGNATURE)]
-[numthreads(1, 1, 1)]
+[numthreads(16, 8, 1)]
 void Accumulation(uint3 threadID : SV_DispatchThreadID)
 {
-    uint sampleIndex = gSettings.sampleIndex;
+    // Skip any shader invocation where the thread ID is outside the screen dimensions, as the
+    // shader will be invoked with more threads than pixels when the dimension are not evenly
+    // divided by the thread group dimensions.
+    uint2 screenDims;
+    gAccumulation.GetDimensions(screenDims.x, screenDims.y);
+    if (any(threadID.xy >= screenDims))
+    {
+        return;
+    }
 
     // Get the screen coordinates (2D) from the thread ID, and the color / alpha from the result of
     // the most recent sample. Treat the result as the "extra" shading value, optionally used below.
@@ -76,6 +86,7 @@ void Accumulation(uint3 threadID : SV_DispatchThreadID)
 
     // If the sample index is greater than zero, blend the new result color with the previous
     // accumulation color.
+    uint sampleIndex = gSettings.sampleIndex;
     if (sampleIndex > 0)
     {
         // Get the previous result. If it has an infinity component, then it represents an error


### PR DESCRIPTION
This modifies the DirectX compute shaders (accumulation and post-processing) to specify thread group dimensions. This is done to improve GPU occupancy, and thus performance. Specifically, this reduces the time required to run those compute shaders, which improves overall rendering performance. For simple scenarios, this can actually double performance as measured in Plasma. In more typical scenarios, this will increase performance by around 10%.

This change was suggested by Neil Bickford, a developer technology engineer from NVIDIA.